### PR TITLE
Better error management and reconnection handling

### DIFF
--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -3,7 +3,6 @@ require 'multi_json'
 
 module Faye
   class Redis
-
     DEFAULT_HOST     = 'localhost'
     DEFAULT_PORT     = 6379
     DEFAULT_DATABASE = 0
@@ -169,7 +168,7 @@ module Faye
         @subscriber = connection.pubsub
 
         @subscriber.on(:connected) do
-          # @subscriber.client('setname', "faye-server/#{@ns}/pubsub[#{Socket.gethostname}][#{Process.pid}]")
+          @subscriber.client('setname', "faye-server/#{@ns}/pubsub[#{Socket.gethostname}][#{Process.pid}]")
         end
 
         @message_channel = @ns + '/notifications/messages'
@@ -185,17 +184,20 @@ module Faye
         @gc = EventMachine.add_periodic_timer(gc, &method(:gc))
         @subscriber.on(:failed) do
           @server.error "Faye::Redis: redis connection failed"
+          connection.pubsub.close_connection
           @redis = nil
         end
+
         connection.on(:failed) do
           @server.error "Faye::Redis: redis connection failed"
+          connection.close_connection
           @redis = nil
         end
         connection.on(:disconnected) do
           @server.info "Faye::Redis: redis disconnected"
         end
         connection.on(:connected) do
-          # @redis.client('setname', "faye-server/#{@ns}[#{Socket.gethostname}][#{Process.pid}]")
+          connection.client('setname', "faye-server/#{@ns}[#{Socket.gethostname}][#{Process.pid}]")
           @server.info "Faye::Redis: redis connected"
         end
        connection.on(:reconnected) do

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -67,17 +67,13 @@ module Faye
       @subscriber.on(:failed) do
         @server.error "Faye::Redis: redis connection failed"
         @redis = nil
-        raise "Could not connect to redis"
       end
       @redis.on(:failed) do
         @server.error "Faye::Redis: redis connection failed"
         @redis = nil
-        raise "Could not connect to redis"
       end
       @redis.on(:disconnected) do
         @server.info "Faye::Redis: redis disconnected"
-        @redis = nil
-        abort('disconnected from redis')
       end
       @redis.on(:connected) do
         @server.info "Faye::Redis: redis connected"


### PR DESCRIPTION
Those changes are:
- adding a log of debug on the two connections (redis + pubsub)\
- removing all the code raising (we don't want the process to restart but to reconnect)
- adding a proper way to reconnect to redis (for the two connections)
- checking that for each operation we have a properly connection configured