### PR TITLE
clear all client data if does not exist

### DIFF
--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'faye-redis'
-  s.version           = '0.3.1'
+  s.version           = '0.3.2'
   s.summary           = 'Redis backend engine for Faye'
   s.author            = 'James Coglan'
   s.email             = 'jcoglan@gmail.com'

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -120,7 +120,7 @@ module Faye
           redis.publish(@message_channel, client_id)
 
           client_exists(client_id) do |exists|
-            redis.del(queue) unless exists
+            destroy_client(client_id) unless exists
           end
         end
       end
@@ -269,4 +269,3 @@ module Faye
 
   end
 end
-


### PR DESCRIPTION
When a client is deleted by the GC, if the server crash between the client deletion and the unsubscribe from channels (different redis operations), the GC will never be able to remove those subscriptions and will continue to broadcast messages to those dead clients what can be really annoying for clients subscribed on a lot of channels like the guys on supervision.

This fix is removing dead clients subscriptions when we find one. The queue will also be cleaned in the `#after_subscriptions_removed` method.

Tested on staging with and without this fix, the behavior is the expected one:

Before, when we removed a client key from the clients list like:
```
ZREM smcc-staging-faye/clients "5yp4ttzmaqsiyvvsz8hwnz7b2u1klq6"
```
The client still had subscriptions:
```
127.0.0.1:6379[1]> SMEMBERS smcc-staging-faye/clients/5yp4ttzmaqsiyvvsz8hwnz7b2u1klq6/channels
1) "/domain_test/all"
2) "/domain_test/private/agent/572721c5776562278b0003bb"
3) "/domain_test/activity/global/572721c5776562278b0003bb"
4) "/domain_test/thread/5c45aff40e2c9972c14f8807"
5) "/domain_test/activity/push/572721c5776562278b0003bb"
6) "/domain_test/queue/workbin_572721c5776562278b0003bb"
7) "/domain_test/supervision/572721c5776562278b0003bb"
```

With the fix, after some seconds:
```
127.0.0.1:6379[1]> SMEMBERS smcc-staging-faye/clients/5yp4ttzmaqsiyvvsz8hwnz7b2u1klq6/channels
(empty list or set)
```