### PR TITLE
Fix race condition on reconnect + reconnect_failed hook RD-25612 RD-25613

### DIFF
--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'faye-redis'
-  s.version           = '0.3.2'
+  s.version           = '0.3.3'
   s.summary           = 'Redis backend engine for Faye'
   s.author            = 'James Coglan'
   s.email             = 'jcoglan@gmail.com'

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -189,7 +189,7 @@ module Faye
             fn = @options[:reconnect_failed] || ->(_, _) {}
             fn.call(count, 'pubsub')
           rescue => e
-            @server.error "Execution of reconnect_failed lambda failed with #{e}"
+            @server.error "Faye::Redis: Execution of reconnect_failed lambda failed with #{e} (pubsub connection)"
           end
         end
         @subscriber.on(:failed) do
@@ -215,7 +215,7 @@ module Faye
             fn = @options[:reconnect_failed] || ->(_, _) {}
             fn.call(count, 'redis')
           rescue => e
-            @server.error "Execution of reconnect_failed lambda failed with #{e}"
+            @server.error "Faye::Redis: Execution of reconnect_failed lambda failed with #{e} (redis connection)"
           end
         end
         connection.on(:failed) do

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -173,58 +173,38 @@ module Faye
           empty_queue(message) if topic == @message_channel
           @server.trigger(:close, message) if topic == @close_channel
         end
-        @subscriber.on(:connected) do
-          @subscriber.client('setname', "faye-server/#{@ns}/pubsub[#{Socket.gethostname}][#{Process.pid}]")
-          @server.info "Faye::Redis: redis pubsub connection connected"
-        end
-        @subscriber.on(:disconnected) do
-          @server.info "Faye::Redis: redis pubsub connection disconnected"
-        end
-        @subscriber.on(:reconnected) do
-          @server.info "Faye::Redis: redis pubsub connection reconnected"
-        end
-        @subscriber.on(:reconnect_failed) do |count|
-          @server.info "Faye::Redis: redis pubsub connection reconnect failed #{count} time(s)"
-          begin
-            fn = @options[:reconnect_failed] || ->(_, _) {}
-            fn.call(count, 'pubsub')
-          rescue => e
-            @server.error "Faye::Redis: Execution of reconnect_failed lambda failed with #{e} (pubsub connection)"
-          end
-        end
-        @subscriber.on(:failed) do
-          @server.error "Faye::Redis: redis pubsub connection failed"
-        end
-        @subscriber.errback do |reason|
-          @server.error "Faye::Redis: redis pubsub connection failed: #{reason}"
-        end
+        register_connection_listeners('pubsub', @subscriber, "faye-server/#{@ns}/pubsub[#{Socket.gethostname}][#{Process.pid}]")
+        register_connection_listeners('redis', connection, "faye-server/#{@ns}[#{Socket.gethostname}][#{Process.pid}]")
 
-        connection.on(:connected) do
-          connection.client('setname', "faye-server/#{@ns}[#{Socket.gethostname}][#{Process.pid}]")
-          @server.info "Faye::Redis: redis connection connected"
-        end
-        connection.on(:disconnected) do
-          @server.info "Faye::Redis: redis connection disconnected"
-        end
-       connection.on(:reconnected) do
-          @server.info "Faye::Redis: redis connection reconnected"
-        end
-        connection.on(:reconnect_failed) do |count|
-          @server.info "Faye::Redis: redis connection reconnect failed #{count} time(s)"
-          begin
-            fn = @options[:reconnect_failed] || ->(_, _) {}
-            fn.call(count, 'redis')
-          rescue => e
-            @server.error "Faye::Redis: Execution of reconnect_failed lambda failed with #{e} (redis connection)"
-          end
-        end
-        connection.on(:failed) do
-          @server.error "Faye::Redis: redis connection failed"
-        end
-        connection.errback do |reason|
-          @server.error "Faye::Redis: redis connection failed: #{reason}"
-        end
         connection
+      end
+    end
+
+    def register_connection_listeners(name, connection, connection_name)
+      connection.on(:connected) do
+        connection.client('setname', connection_name)
+        @server.info "Faye::Redis: #{name} connection connected"
+      end
+      connection.on(:disconnected) do
+        @server.info "Faye::Redis: #{name} connection disconnected"
+      end
+      connection.on(:reconnected) do
+        @server.info "Faye::Redis: #{name} connection reconnected"
+      end
+      connection.on(:reconnect_failed) do |count|
+        @server.info "Faye::Redis: #{name} connection reconnect failed #{count} time(s)"
+        begin
+          fn = @options[:reconnect_failed] || ->(_, _) {}
+          fn.call(count, name)
+        rescue => e
+          @server.error "Faye::Redis: Execution of reconnect_failed lambda failed with #{e} (#{name} connection)"
+        end
+      end
+      connection.on(:failed) do
+        @server.error "Faye::Redis: #{name} connection failed"
+      end
+      connection.errback do |reason|
+        @server.error "Faye::Redis: #{name} connection failed: #{reason}"
       end
     end
 


### PR DESCRIPTION
This commit removes the unnecessary and problematic call to reconnect. The underlying EventMachine::Hiredis::Client already handle the reconnection every 0.5 seconds. Having a second timer also running every 0.5s can make the two reconnections overlapse and eventually it can make the reconnection to fail for a while. The reason is that evenmachine C extension uses non blocking sockets so if the two timers are executed during the same event loop the execution will be as follow:
- Execute timer with reconnect call (from em-hiredis) -> this will open a socket and will not wait for it to be oppened
- Execute timer with reconnect! call (from faye-redis-ruby) -> The socket opened from the previous timer is set to be closed later (actually in the _CleanupSockets) and call a reconnect at next_tick
- next_tick is executed: - All sockets are read from and/or written unless for sockets scheduled to be closed as in our case. - Reconnect is executed but notices we already have one socket still open (even if it's scheduled to be closed ) for this redis connection so it does nothing.
- _CleanupSockets is called so our redis socket is closed which is triggering the reconnect_failed event and this can goes on for a while until the 2 timers are not executed during the same event loop.

The code for eventmachine can be seen in the em.cpp file in eventmachine github repository.