### PR TITLE
Fail fast when redis is not accessible without sending tcp FIN RD-25611 

### DIFF
--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
             Dir.glob('lib/**/*.rb')
 
   s.add_dependency 'eventmachine', '>= 0.12.0'
-  s.add_dependency 'em-hiredis', '>= 0.2.0'
+  s.add_dependency 'em-hiredis', '>= 0.3.1'
   s.add_dependency 'multi_json', '>= 1.0.0'
 
   s.add_development_dependency 'rspec'

--- a/faye-redis.gemspec
+++ b/faye-redis.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'faye-redis'
-  s.version           = '0.3.3'
+  s.version           = '0.3.4'
   s.summary           = 'Redis backend engine for Faye'
   s.author            = 'James Coglan'
   s.email             = 'jcoglan@gmail.com'

--- a/lib/faye/redis.rb
+++ b/lib/faye/redis.rb
@@ -156,7 +156,7 @@ module Faye
         auth             = @options[:password]         || nil
         gc               = @options[:gc]               || DEFAULT_GC
         socket           = @options[:socket]           || nil
-        inactivity_check = @options[:inactivity_check] || { enabled: false }
+        inactivity_check = @options[:inactivity_check] || {}
 
         connection = if uri
           EventMachine::Hiredis.connect(uri)
@@ -176,7 +176,7 @@ module Faye
         end
         register_connection_listeners('pubsub', @subscriber, "faye-server/#{@ns}/pubsub[#{Socket.gethostname}][#{Process.pid}]")
         register_connection_listeners('redis', connection, "faye-server/#{@ns}[#{Socket.gethostname}][#{Process.pid}]")
-        if inactivity_check[:enabled]
+        if inactivity_check_enabled?(inactivity_check)
           @server.info "Faye::Redis: Configuring inactivity check for redis connection and pubsub with trigger_secs=#{inactivity_check[:trigger_secs]} and response_timeout=#{inactivity_check[:response_timeout]}"
           configure_inactivity_check(connection, inactivity_check)
           configure_inactivity_check(@subscriber, inactivity_check)
@@ -212,6 +212,10 @@ module Faye
       connection.errback do |reason|
         @server.error "Faye::Redis: #{name} connection failed: #{reason}"
       end
+    end
+
+    def inactivity_check_enabled?(inactivity_check)
+      inactivity_check[:trigger_secs] || inactivity_check[:response_timeout]
     end
 
     def configure_inactivity_check(connection, inactivity_check)


### PR DESCRIPTION
This commit handles scenario where HA is handled via DNS update as this is done in elasticache.
In this scenario if redis master crashes or if it's not accessible anymore elasticache will promote a secondary as master and update the DNS to point to the new master.

However the redis connection on client side has no way to know it should close the socket since it didn't receive a FIN or RST packet.
The way tcp handles this is to retransmit packet up to 15 times (/proc/sys/net/ipv4/tcp_retries2) with a backoff strategy of **2 capped to 60 seconds.
This means it will timeout after ~ 8 minutes or when the old primary is back up to send a RST which is also takes about 8 minutes on AWS.

This commit takes advantage of the implementation done in em-hiredis that exposes a periodic timer to check connections. This commits exposes it to end user.